### PR TITLE
cut down on complexity and rubocop errors

### DIFF
--- a/lib/audio_book_creator.rb
+++ b/lib/audio_book_creator.rb
@@ -4,6 +4,10 @@ module AudioBookCreator
   def self.sanitize_filename(*filenames)
     filenames.flatten.compact.join(".").gsub(/[^-._a-z0-9A-Z]/, "-").gsub(/--*/, "-").gsub(/-$/, "").downcase
   end
+
+  def self.should_write?(filename, force = false)
+    force || !File.exist?(filename)
+  end
 end
 
 require "audio_book_creator/page_db"

--- a/lib/audio_book_creator/binder.rb
+++ b/lib/audio_book_creator/binder.rb
@@ -24,31 +24,40 @@ module AudioBookCreator
     def create(chapters)
       raise "No Chapters" if chapters.empty?
 
-      if force || !File.exist?(filename)
-        puts "creating #{filename}" if verbose
-        Runner.new.run!("abbinder",
-                        verbose: verbose,
-                        params:  {
-                          "-a" => author,
-                          "-t" => "\"#{title || base_dir}\"",
-                          "-b" => bit_rate,
-                          "-c" => channels,
-                          "-r" => sample_rate,
-                          "-g" => "Audiobook",
-                          "-l" => max_hours,
-                          "-o" => filename,
-                          # "-v" => verbose,
-                          # "-A" => nil, #    add audiobook to iTunes
-                          # -C file.png cover image
-                          nil  => chapters.map { |ch| [ctitle(ch), cfilename(ch)] },
-                        })
+      if AudioBookCreator.should_write?(filename, force)
+        Runner.new.run!("abbinder", verbose: verbose, params: params(chapters))
       end
     end
 
     private
 
+    def params(chapters)
+      {
+        "-a" => author,
+        "-t" => book_title,
+        "-b" => bit_rate,
+        "-c" => channels,
+        "-r" => sample_rate,
+        "-g" => "Audiobook",
+        "-l" => max_hours,
+        "-o" => filename,
+        # "-v" => verbose,
+        # "-A" => nil, #    add audiobook to iTunes
+        # "-C" => "file.png" cover image
+        nil  => chapter_params(chapters),
+      }
+    end
+
+    def book_title
+      "\"#{@title || @base_dir}\""
+    end
+
     def filename
-      AudioBookCreator.sanitize_filename(title,"m4b")
+      AudioBookCreator.sanitize_filename(title, "m4b")
+    end
+
+    def chapter_params(chapters)
+      chapters.map { |ch| [ctitle(ch), cfilename(ch)] }
     end
 
     def ctitle(chapter)

--- a/lib/audio_book_creator/cli.rb
+++ b/lib/audio_book_creator/cli.rb
@@ -44,33 +44,22 @@ module AudioBookCreator
     def parse(argv = [], _env = {})
       options = OptionParser.new do |opts|
         opts.program_name = File.basename($PROGRAM_NAME)
-        opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] title url [url]"
-        opts.on("-v", "--[no-]verbose", "Run verbosely") { |v| self[:verbose] = v }
-        opts.on(      "--title STRING", "Content css (e.g.: h1)") { |v| self[:title_path] = v }
-        opts.on(      "--body STRING", "Content css (e.g.: p)") { |v| self[:body_path] = v }
-        opts.on(      "--link STRING", "Follow css (e.g.: a.Next)") { |v| self[:link_path] = v }
-        opts.on(      "--no-max", "Don't limit the number of pages to visit") { self[:max] = nil }
-        opts.on(      "--max NUMBER", Integer, "Maximum number of pages to visit (default: #{self[:max]})") do |v|
-          self[:max] = v
-        end
-        opts.on("--max-p NUMBER", Integer, "Max paragraphs per chapter (testing only)") do |v|
-          self[:max_paragraphs] = v
-        end
-        opts.on("--force-audio", "Regerate the audio") { |v| self[:regen_audio] = v }
-        opts.on("--force-html", "Regerate the audio") { |v| self[:regen_html] = v }
-        opts.on("--multi-site", "Allow spider to visit multiple sites") { |v| self[:multi_site] = v }
-        opts.on("--rate NUMBER", Integer, "Set words per minute") { |v| self[:rate] = v }
-        opts.on("--voice STRING", "Set speaker voice") { |v| self[:voice] = v }
-        opts.on("--cache STRONG", "Directory to hold files") { |v| self[:base_dir] = v }
-        opts.on_tail("-h", "--help", "Show this message") do
-          puts opts.to_s
-          exit 0
-        end
-
-        opts.on_tail("--version", "Show version") do
-          puts "audio_book_creator #{::AudioBookCreator::VERSION}"
-          exit 0
-        end
+        opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] title url [url] [...]"
+        option(opts, :verbose, "-v", "--verbose", "Run verbosely")
+        option(opts, :title_path, "--title STRING", "Content css (e.g.: h1)")
+        option(opts, :body_path, "--body STRING", String, "Content css (e.g.: p)")
+        option(opts, :link_path, "--link STRING", String, "Follow css (e.g.: a.Next)")
+        option(opts, :max, "--no-max", "Don't limit the number of pages to verbose")
+        option(opts, :max, "--max NUMBER", Integer, "Maximum number of pages to visit (default: 10)")
+        option(opts, :max_paragraphs, "--max-p NUMBER", Integer, "Max paragraphs per chapter (testing only)")
+        option(opts, :regen_audio, "--force-audio", "Regerate the audio")
+        option(opts, :regen_html, "--force-html", "Regerate the audio")
+        option(opts, :multi_site, "--multi-site", "Allow spider to visit multiple sites")
+        option(opts, :rate, "--rate NUMBER", Integer, "Set words per minute")
+        option(opts, :voice, "--voice STRING", "Set speaker voice")
+        option(opts, :base_dir, "--cache STRONG", "Directory to hold files")
+        tail_option(opts, "audio_book_creator #{::AudioBookCreator::VERSION}", "--version", "Show version")
+        tail_option(opts, opts.to_s, "-h", "--help", "Show this message")
       end
       options.parse!(argv)
       set_args(argv, options.to_s)
@@ -117,6 +106,17 @@ module AudioBookCreator
     end
 
     private
+
+    def option(opts, value, *args)
+      opts.on(*args) { |v| self[value] = v }
+    end
+
+    def tail_option(opts, message, *args)
+      opts.on_tail(*args) do
+        puts message
+        exit 1
+      end
+    end
 
     def default(key, value)
       self[key] = value if self[key].nil?

--- a/lib/audio_book_creator/speaker.rb
+++ b/lib/audio_book_creator/speaker.rb
@@ -26,27 +26,29 @@ module AudioBookCreator
 
     def say(chapter)
       raise "Empty chapter" if chapter.empty?
-
-      sound_filename = "#{base_dir}/#{chapter.filename}.m4a"
-      text_filename = "#{base_dir}/#{chapter.filename}.txt"
-      File.write(text_filename, chapter.to_s) if force || !File.exist?(text_filename)
-
-      if force || !File.exist?(sound_filename)
-        # -f text_filename VS. options = { :stdin_data => input}
-        Runner.new.run!("say",
-                        verbose: verbose,
-                        params:  {
-                          "-v" => voice,
-                          "-r" => rate,
-                          "-f" => text_filename,
-                          "-o" => sound_filename,
-                          # "--file-format" => m4af,m4bf
-                          # "--data-format" => :format, # or aac / aac@8000
-                          # "--channels" => 1, # doesn't seem to do anything. voices are 1 anyway
-                          # "--bitrate" => 20_500,  # doesn't do anything
-                          # "--quality" => 50,  # 0..127 - doesn't seem to do anything
-                        })
+      File.write(text_filename(chapter), chapter.to_s) if AudioBookCreator.should_write?(text_filename(chapter), force)
+      if AudioBookCreator.should_write?(sound_filename(chapter), force)
+        Runner.new.run!("say", verbose: verbose, params: params(chapter))
       end
+    end
+
+    private
+
+    def params(chapter)
+      {
+        "-v" => voice,
+        "-r" => rate,
+        "-f" => text_filename(chapter),
+        "-o" => sound_filename(chapter),
+      }
+    end
+
+    def sound_filename(chapter)
+      "#{base_dir}/#{chapter.filename}.m4a"
+    end
+
+    def text_filename(chapter)
+      "#{base_dir}/#{chapter.filename}.txt"
     end
   end
 end

--- a/spec/audio_book_creator_spec.rb
+++ b/spec/audio_book_creator_spec.rb
@@ -26,6 +26,27 @@ describe AudioBookCreator do
     it "should support titles with extra stuff" do
       expect(subject.sanitize_filename("title,for!")).to eq("title-for")
     end
+  end
 
+  context ".should_write" do
+    it "should know file does not exist" do
+      expect(File).to receive(:exist?).with("x").and_return(false)
+      expect(subject.should_write?("x", false)).to be_truthy
+    end
+
+    it "should respect force" do
+      expect(File).not_to receive(:exist?)
+      expect(subject.should_write?("x", true)).to be_truthy
+    end
+
+    it "should know file exists" do
+      expect(File).to receive(:exist?).with("x").and_return(true)
+      expect(subject.should_write?("x", false)).not_to be_truthy
+    end
+
+    it "should assume force is false" do
+      expect(File).to receive(:exist?).with("x").and_return(true)
+      expect(subject.should_write?("x")).not_to be_truthy
+    end
   end
 end

--- a/spec/binder_spec.rb
+++ b/spec/binder_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe AudioBookCreator::Binder do
-  subject { described_class.new(title: "title", base_dir: "dir")}
+  subject { described_class.new(title: "title", base_dir: "dir") }
   it "should require a chapter" do
     expect { subject.create([]) }.to raise_error
   end
@@ -34,7 +34,6 @@ describe AudioBookCreator::Binder do
     expect(File).to receive(:exist?).and_return(false)
 
     expect_runner.to receive(:system).and_return(true)
-    expect(subject).to receive(:puts).with(/^creating/)
     expect_runner.to receive(:puts).with(/^run:/)
     expect_runner.to receive(:puts).with("success")
     expect_runner.to receive(:puts).with("").twice

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -135,7 +135,7 @@ describe AudioBookCreator::Cli do
 
     it "should have no max" do
       subject.parse(%w(title http://www.site.com/ --no-max))
-      expect(subject.spider.max).to be_nil
+      expect(subject.spider.max).not_to be_truthy
     end
 
     it "should have a max" do
@@ -221,7 +221,7 @@ describe AudioBookCreator::Cli do
       expect(subject.binder.channels).to eq(1)
       expect(subject.binder.max_hours).to eq(7)
       expect(subject.binder.bit_rate).to eq(32)
-      expect(subject.binder.sample_rate).to eq(22050)
+      expect(subject.binder.sample_rate).to eq(22_050)
     end
 
     it "should set verbose" do

--- a/spec/page_db_spec.rb
+++ b/spec/page_db_spec.rb
@@ -1,7 +1,7 @@
 require_relative "spec_helper"
 
 describe AudioBookCreator::PageDb do
-  subject { described_class.new(":memory:")}
+  subject { described_class.new(":memory:") }
 
   it "should not create a file" do
     expect(File).not_to be_exist(":memory:")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,13 +17,13 @@ end
 
 module HtmlHelpers
   def link(url)
-    %{<a href="#{url}">link</a>"}
+    %(<a href="#{url}">link</a>")
   end
 
   def page(title, *args)
-    %{<html><head><title>#{title}</title></head>
+    %(<html><head><title>#{title}</title></head>
       <body>#{Array(args).join(" ")}</body>
-      </html>}
+      </html>)
   end
 
   # site helpers

--- a/spec/spider_spec.rb
+++ b/spec/spider_spec.rb
@@ -116,7 +116,7 @@ describe AudioBookCreator::Spider do
   end
 
   context "#local_href" do
-    let (:first_page) { "http://www.thesite.com/book/page1.html" }
+    let(:first_page) { "http://www.thesite.com/book/page1.html" }
     before do
       # establish base site (we can't venture to other sites)
       subject.visit(first_page)


### PR DESCRIPTION
Hoping to reduce code complexity. Hard to determine locally

Reducing rubocop warnings locally.
- cli uses helper methods to build options
- binder uses helpers to create params list and book_title
- speaker uses helpers to create param list and titles
- audio_book_creator module: move common file exists logic
