### PR TITLE
introduce --mute option

### DIFF
--- a/lib/audio_book_creator.rb
+++ b/lib/audio_book_creator.rb
@@ -55,6 +55,7 @@ require "audio_book_creator/spider"
 require "audio_book_creator/editor"
 # flow
 require "audio_book_creator/speaker"
+require "audio_book_creator/speaker_mute"
 require "audio_book_creator/binder"
 require "audio_book_creator/book_creator" # full workflow
 require "audio_book_creator/conductor" # creates components of flow

--- a/lib/audio_book_creator/binder.rb
+++ b/lib/audio_book_creator/binder.rb
@@ -11,7 +11,7 @@ module AudioBookCreator
     end
 
     def create(chapters)
-      raise "No Chapters" if chapters.nil? || chapters.empty?
+      raise "No Chapters" if chapters.nil? || chapters.compact.empty?
 
       AudioBookCreator.optionally_run(book_def.filename, force) do
         ["abbinder", params: params(chapters)]

--- a/lib/audio_book_creator/cli.rb
+++ b/lib/audio_book_creator/cli.rb
@@ -46,6 +46,7 @@ module AudioBookCreator
           o.opt(:regen_audio, "--force-audio", "Regerate the audio")
           o.opt(:rate, "--rate NUMBER", Integer, "Set words per minute")
           o.opt(:voice, "--voice STRING", "Set speaker voice")
+          o.opt(:mute, "--mute", "Don't speak")
         end
         opt(opts, book_def) do |o|
           o.opt(:base_dir, "--base-dir STRING", "Directory to hold files")

--- a/lib/audio_book_creator/conductor.rb
+++ b/lib/audio_book_creator/conductor.rb
@@ -48,7 +48,7 @@ module AudioBookCreator
     end
 
     def speaker
-      @speaker ||= Speaker.new(speaker_def, book_def)
+      @speaker ||= speaker_def.mute ? SpeakerMute.new(speaker_def, book_def) : Speaker.new(speaker_def, book_def)
     end
 
     def binder

--- a/lib/audio_book_creator/speaker_def.rb
+++ b/lib/audio_book_creator/speaker_def.rb
@@ -21,8 +21,10 @@ module AudioBookCreator
     attr_accessor :bit_rate
     attr_accessor :sample_rate
     attr_accessor :regen_audio
+    attr_accessor :mute
 
     def initialize(options = {})
+      # for the spec only
       options.each { |n, v| public_send("#{n}=", v) }
 
       # for speaking the chapter
@@ -34,6 +36,7 @@ module AudioBookCreator
       @bit_rate  ||= 32
       @max_hours ||= 7
       @sample_rate ||= 22_050
+      @mute      ||= false
     end    
   end
 end

--- a/lib/audio_book_creator/speaker_mute.rb
+++ b/lib/audio_book_creator/speaker_mute.rb
@@ -1,0 +1,18 @@
+module AudioBookCreator
+  class SpeakerMute < Speaker
+    # def initialize(speaker_def, book_def)
+    #   @speaker_def = speaker_def
+    #   @book_def = book_def
+    # end
+
+    def say(chapter)
+      raise "Empty Chapter" if chapter.empty?
+      text_filename = chapter_text_filename(chapter)
+      sound_filename = chapter_sound_filename(chapter)
+
+      AudioBookCreator.optionally_write(text_filename, force) { chapter.to_s }
+
+      nil
+    end
+  end
+end

--- a/spec/audio_book_creator/binder_spec.rb
+++ b/spec/audio_book_creator/binder_spec.rb
@@ -93,6 +93,7 @@ describe AudioBookCreator::Binder do
     expect_runner.not_to receive(:system)
     expect { subject.create(nil) }.to raise_error("No Chapters")
     expect { subject.create([]) }.to raise_error("No Chapters")
+    expect { subject.create([nil, nil]) }.to raise_error("No Chapters")
   end
 
   private

--- a/spec/audio_book_creator/cli_spec.rb
+++ b/spec/audio_book_creator/cli_spec.rb
@@ -287,6 +287,13 @@ describe AudioBookCreator::Cli do
         expect(subject.surfer_def.regen_html).to be_truthy
       end
     end
+
+    context "#existing" do
+      it "sets" do
+        subject.parse(%w(http://site.com/title --existing))
+        expect(subject.surfer_def.existing).to be_truthy
+      end
+    end
   end
 
   describe "#conductor" do


### PR DESCRIPTION
`say` is not available in OSX

introduce --mute option. so it downloads the text, but doesn't create an audio book.

Just a temporary option